### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A Model Context Protocol (MCP) server built with mcp-framework. This MCP provides tools
 for interacting with your YNAB budgets setup at https://ynab.com
 
+<a href="https://glama.ai/mcp/servers/@calebl/ynab-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@calebl/ynab-mcp-server/badge" alt="YNAB Server MCP server" />
+</a>
+
 In order to have an AI interact with this tool, you will need to get your Personal Access Token
 from YNAB: https://api.ynab.com/#personal-access-tokens
 


### PR DESCRIPTION
This PR adds a badge for the [YNAB MCP Server](https://glama.ai/mcp/servers/@calebl/ynab-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@calebl/ynab-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@calebl/ynab-mcp-server/badge" alt="YNAB Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.