### PR TITLE
add new approve transaction tool

### DIFF
--- a/.cursor/rules/ynabapi.mdc
+++ b/.cursor/rules/ynabapi.mdc
@@ -1,0 +1,9 @@
+---
+description: directions for generating code for new tools
+globs: 
+alwaysApply: true
+---
+
+# Rules for creating and update YNAB tools
+
+- check the type definition for the YNAB npm library here [index.d.ts](mdc:node_modules/ynab/dist/index.d.ts). Read from the imported types found in "models" subfolder if necessary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2024-03-26
+
+### Added
+- New `ApproveTransaction` tool for approving existing transactions in YNAB
+  - Can approve/unapprove transactions by ID
+  - Works in conjunction with GetUnapprovedTransactions tool
+  - Preserves existing transaction data when updating approval status
+- Added Cursor rules for YNAB API development
+  - New `.cursor/rules/ynabapi.mdc` file
+  - Provides guidance for working with YNAB types and API endpoints
+  - Helps maintain consistency in tool development
+
+### Changed
+- Updated project structure documentation to include `.cursor/rules` directory
+- Enhanced README with documentation for the new ApproveTransaction tool 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Available tools:
 * CreateTransaction - creates a transaction for a specified budget and account.
   * example prompt: `Add a transaction to my Ally account for $3.98 I spent at REI today`
   * requires GetBudget to be called first so we know the account id
+* ApproveTransaction - approves an existing transaction in your YNAB budget
+  * requires a transaction ID to approve
+  * can be used in conjunction with GetUnapprovedTransactions to approve pending transactions
 
 Next:
 * move to using budget by month call instead of getting categories from the entire budget: https://api.ynab.com/v1#/Months/getBudgetMonth
@@ -65,6 +68,8 @@ ynab-mcp-server/
 ├── src/
 │   ├── tools/        # MCP Tools
 │   └── index.ts      # Server entry point
+├── .cursor/
+│   └── rules/        # Cursor AI rules for code generation
 ├── package.json
 └── tsconfig.json
 ```

--- a/dist/tools/ApproveTransactionTool.js
+++ b/dist/tools/ApproveTransactionTool.js
@@ -1,0 +1,62 @@
+import { MCPTool, logger } from "mcp-framework";
+import { z } from "zod";
+import * as ynab from "ynab";
+class ApproveTransactionTool extends MCPTool {
+    name = "approve_transaction";
+    description = "Approves an existing transaction in your YNAB budget.";
+    api;
+    budgetId;
+    constructor() {
+        super();
+        this.api = new ynab.API(process.env.YNAB_API_TOKEN || "");
+        this.budgetId = process.env.YNAB_BUDGET_ID || "";
+    }
+    schema = {
+        budgetId: {
+            type: z.string().optional(),
+            description: "The id of the budget containing the transaction (optional, defaults to the budget set in the YNAB_BUDGET_ID environment variable)",
+        },
+        transactionId: {
+            type: z.string(),
+            description: "The id of the transaction to approve",
+        },
+        approved: {
+            type: z.boolean().default(true),
+            description: "Whether the transaction should be marked as approved",
+        },
+    };
+    async execute(input) {
+        const budgetId = input.budgetId || this.budgetId;
+        if (!budgetId) {
+            throw new Error("No budget ID provided. Please provide a budget ID or set the YNAB_BUDGET_ID environment variable.");
+        }
+        try {
+            // First, get the existing transaction to ensure we don't lose any data
+            const existingTransaction = await this.api.transactions.getTransactionById(budgetId, input.transactionId);
+            if (!existingTransaction.data.transaction) {
+                throw new Error("Transaction not found");
+            }
+            const existingTransactionData = existingTransaction.data.transaction;
+            const transaction = {
+                transaction: {
+                    approved: input.approved,
+                }
+            };
+            const response = await this.api.transactions.updateTransaction(budgetId, existingTransactionData.id, transaction);
+            if (!response.data.transaction) {
+                throw new Error("Failed to update transaction - no transaction data returned");
+            }
+            return {
+                success: true,
+                transactionId: response.data.transaction.id,
+                message: "Transaction updated successfully",
+            };
+        }
+        catch (error) {
+            logger.error(`Error getting unapproved transactions for budget ${budgetId}:`);
+            logger.error(JSON.stringify(error, null, 2));
+            return `Error getting unapproved transactions: ${error instanceof Error ? error.message : JSON.stringify(error)}`;
+        }
+    }
+}
+export default ApproveTransactionTool;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ynab-mcp-server MCP server",
   "author": "Caleb LeNoir <caleb.lenoir@hey.com>",
   "type": "module",

--- a/src/tools/ApproveTransactionTool.ts
+++ b/src/tools/ApproveTransactionTool.ts
@@ -1,0 +1,89 @@
+import { MCPTool, logger } from "mcp-framework";
+import { z } from "zod";
+import * as ynab from "ynab";
+
+interface UpdateTransactionInput {
+  budgetId?: string;
+  transactionId: string;
+  approved?: boolean;
+}
+
+class ApproveTransactionTool extends MCPTool<UpdateTransactionInput> {
+  name = "approve_transaction";
+  description = "Approves an existing transaction in your YNAB budget.";
+
+  private api: ynab.API;
+  private budgetId: string;
+
+  constructor() {
+    super();
+    this.api = new ynab.API(process.env.YNAB_API_TOKEN || "");
+    this.budgetId = process.env.YNAB_BUDGET_ID || "";
+  }
+
+  schema = {
+    budgetId: {
+      type: z.string().optional(),
+      description: "The id of the budget containing the transaction (optional, defaults to the budget set in the YNAB_BUDGET_ID environment variable)",
+    },
+    transactionId: {
+      type: z.string(),
+      description: "The id of the transaction to approve",
+    },
+    approved: {
+      type: z.boolean().default(true),
+      description: "Whether the transaction should be marked as approved",
+    },
+  };
+
+  async execute(input: UpdateTransactionInput) {
+    const budgetId = input.budgetId || this.budgetId;
+
+    if (!budgetId) {
+      throw new Error("No budget ID provided. Please provide a budget ID or set the YNAB_BUDGET_ID environment variable.");
+    }
+
+    try {
+      // First, get the existing transaction to ensure we don't lose any data
+      const existingTransaction = await this.api.transactions.getTransactionById(budgetId, input.transactionId);
+
+      if (!existingTransaction.data.transaction) {
+        throw new Error("Transaction not found");
+      }
+
+      const existingTransactionData = existingTransaction.data.transaction;
+
+      const transaction: ynab.PutTransactionWrapper = {
+        transaction: {
+          approved: input.approved,
+        }
+      };
+
+      const response = await this.api.transactions.updateTransaction(
+        budgetId,
+        existingTransactionData.id,
+        transaction
+      );
+
+      if (!response.data.transaction) {
+        throw new Error("Failed to update transaction - no transaction data returned");
+      }
+
+      return {
+        success: true,
+        transactionId: response.data.transaction.id,
+        message: "Transaction updated successfully",
+      };
+    } catch (error) {
+      logger.error(
+        `Error getting unapproved transactions for budget ${budgetId}:`
+      );
+      logger.error(JSON.stringify(error, null, 2));
+      return `Error getting unapproved transactions: ${
+        error instanceof Error ? error.message : JSON.stringify(error)
+      }`;
+    }
+  }
+}
+
+export default ApproveTransactionTool;


### PR DESCRIPTION
## [0.1.2] - 2024-03-26

### Added
- New `ApproveTransaction` tool for approving existing transactions in YNAB
  - Can approve/unapprove transactions by ID
  - Works in conjunction with GetUnapprovedTransactions tool
  - Preserves existing transaction data when updating approval status
- Added Cursor rules for YNAB API development
  - New `.cursor/rules/ynabapi.mdc` file
  - Provides guidance for working with YNAB types and API endpoints
  - Helps maintain consistency in tool development

### Changed
- Updated project structure documentation to include `.cursor/rules` directory
- Enhanced README with documentation for the new ApproveTransaction tool 