### PR TITLE
Bump to 0.2.0 to unblock republishing to npm (fixes #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-09
+
+The npm-published `0.1.2` package predates this project's migration off
+`mcp-framework` and still ships that older implementation, even though
+`main` moved on some time ago. This release republishes `main` as-is so
+npm and GitHub stop diverging.
+
+### Fixed
+- Fixed invalid MCP content type in tool error responses. The old
+  `mcp-framework`-based implementation returned `{ type: "error", ... }`
+  from failed tool calls, which is not a valid MCP content block type
+  (valid types are `text`, `image`, `audio`, `resource_link`, `resource`).
+  MCP clients rejected these responses with a schema validation error
+  instead of surfacing the actual failure message, making it impossible
+  to tell from the client side whether a mutating call like
+  `create_transaction` succeeded or failed. Tools now return errors as
+  `type: "text"` content carrying a JSON `{ success: false, error }`
+  payload via the shared `getErrorMessage` helper.
+- Fixed inaccurate generated input schemas for optional boolean fields
+  (e.g. `cleared`, `approved` on `create_transaction`). The old
+  `mcp-framework`-based JSON schema generation didn't unwrap
+  `ZodOptional`, so these fields were reported as `type: "string"` to
+  callers despite the underlying validator requiring real booleans.
+
+### Changed
+- Migrated from `mcp-framework` to the official `@modelcontextprotocol/sdk`
+  for tool registration and the stdio transport.
+- Renamed all tools with a `ynab_` prefix (e.g. `create_transaction` ->
+  `ynab_create_transaction`) to avoid collisions with other MCP servers.
+- Added consistent error handling across all tools via a shared
+  `getErrorMessage` utility, including unwrapping YNAB API error
+  response bodies.
+
+### Added
+- New tools: `ListCategories`, `ListAccounts`, `ListScheduledTransactions`,
+  `ListMonths`, `ListPayees`, `GetTransactions`, `ImportTransactions`,
+  `DeleteTransaction`, `UpdateTransaction`, `UpdateCategoryBudget`,
+  `BulkApproveTransactions`.
+
 ## [0.1.2] - 2024-03-26
 
 ### Added

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,7 +21,7 @@ import * as ImportTransactionsTool from "./tools/ImportTransactionsTool.js";
 import * as ListMonthsTool from "./tools/ListMonthsTool.js";
 const server = new McpServer({
     name: "ynab-mcp-server",
-    version: "0.1.2",
+    version: "0.2.0",
 });
 // Initialize YNAB API
 const api = new ynab.API(process.env.YNAB_API_TOKEN || "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab-mcp-server",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@types/axios": "^0.14.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "ynab-mcp-server MCP server",
   "author": "Caleb LeNoir <caleb.lenoir@hey.com>",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import * as ListMonthsTool from "./tools/ListMonthsTool.js";
 
 const server = new McpServer({
   name: "ynab-mcp-server",
-  version: "0.1.2",
+  version: "0.2.0",
 });
 
 // Initialize YNAB API


### PR DESCRIPTION
## Summary

Fixes #31.

The npm-published `0.1.2` package predates this project's migration off `mcp-framework` (#15) and still ships that older implementation, even though `main` moved on some time ago. As a result, npm and GitHub have quietly diverged since April 2025 — anyone installing via `npx ynab-mcp-server` gets the old, buggy build while `main` already contains the fix.

Concretely, the old `mcp-framework`-based build has two bugs that are already fixed on `main` by virtue of the SDK migration, but were never shipped:

1. **Invalid MCP content type on tool errors.** `mcp-framework`'s `BaseTool.createErrorResponse` returns `{ content: [{ type: "error", text: ... }] }`. `"error"` isn't a valid MCP content block type (valid types are `text`, `image`, `audio`, `resource_link`, `resource`), so MCP clients reject these responses with a schema validation error instead of showing the real failure message. For a mutating tool like `create_transaction`, this means a client can't tell whether the call actually succeeded or failed without independently re-checking state. `main`'s tools already return `type: "text"` with a JSON `{ success, error }` payload via the shared `getErrorMessage` helper, so this is fixed — just not released.
2. **Wrong generated input schema for optional booleans.** `mcp-framework`'s `getJsonSchemaType` doesn't unwrap `ZodOptional`, so fields like `cleared`/`approved` on `create_transaction` are reported to callers as `type: "string"` even though the validator requires real booleans. This is moot on `main` since tool schemas are now passed straight through to `@modelcontextprotocol/sdk`.

This PR doesn't change any tool logic — it:
- Bumps `package.json`/`src/index.ts` version from `0.1.2` to `0.2.0`
- Rebuilds `dist/` from current `main` source
- Adds a `CHANGELOG.md` entry summarizing everything that's shipped since `0.1.2` (SDK migration, tool renaming with `ynab_` prefix, new tools, consistent error handling), so this is ready for `npm publish`

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — 169/169 tests pass
- [ ] Maintainer: `npm publish` after merge so the fix actually reaches users